### PR TITLE
Add bower whitelist

### DIFF
--- a/bower_whitelist.json
+++ b/bower_whitelist.json
@@ -1,0 +1,7 @@
+{
+	'https://github.com/angular/bower-angular': 'angular',
+	'https://github.com/twbs/bootstrap': 'bootstrap',
+	'https://github.com/FortAwesome/Font-Awesome': 'fontawesome',
+	'https://github.com/jquery/jquery': 'jquery',
+	'https://github.com/jabranr/Socialmedia': 'socialmedia'
+}


### PR DESCRIPTION
Add bower whitelist to handle bower duplicates. For example there are several jquery packages with same url but different names(jq, jqu, jquery and so). We use this list to show only the correct one.

We get file from here: https://github.com/bower/search/blob/gh-pages/js/config/whitelist.js
