### PR TITLE
Use https instead of git

### DIFF
--- a/git/etc/gitconfig
+++ b/git/etc/gitconfig
@@ -3,3 +3,6 @@
 	autocrlf = input
 [http]
 	sslCAinfo = /bin/curl-ca-bundle.crt
+[url "https://"]
+	insteadOf = git://
+


### PR DESCRIPTION
On our sit machines "git ls-remote" (using the git protocol) command seems to fail sporadic.

After research I found that this issues may be caused by different problems:
 - The port which git protocol uses(9418) is closed
 - Problem with the proxy(if you use such)
 - Too many connections to GitHub.

The solution that was suggested is to use https instead.

https://github.com/bower/bower/issues/713
https://github.com/bower/bower/issues/1245

Teampulse item: #288542
http://teampulse.telerik.com/view#item/288542